### PR TITLE
Add Send trait for types as cargo feature

### DIFF
--- a/src/generators/lib.rs
+++ b/src/generators/lib.rs
@@ -1210,10 +1210,10 @@ pub fn generate_opaque_type(key: &String, methods: &Vec<&Function>, api: &Api) -
             pointer: *mut ffi::#opaque_type,
         }
 
-        #[cfg(feature = "send-sync")]
+        #[cfg(feature = "sync")]
         unsafe impl Send for #name {}
 
-        #[cfg(feature = "send-sync")]
+        #[cfg(feature = "sync")]
         unsafe impl Sync for #name {}
 
         impl #name {

--- a/src/generators/lib.rs
+++ b/src/generators/lib.rs
@@ -1210,6 +1210,12 @@ pub fn generate_opaque_type(key: &String, methods: &Vec<&Function>, api: &Api) -
             pointer: *mut ffi::#opaque_type,
         }
 
+        #[cfg(feature = "send-sync")]
+        unsafe impl Send for #name {}
+
+        #[cfg(feature = "send-sync")]
+        unsafe impl Sync for #name {}
+
         impl #name {
             #[inline]
             pub fn from(pointer: *mut ffi::#opaque_type) -> Self {


### PR DESCRIPTION
[FMOD describes their API as fully thread safe](https://www.fmod.com/docs/2.02/api/core-guide.html#non-blocking-loads-threads-and-thread-safety). However, when trying to use the default types of libfmod, I get error messages stating that I can't use these types across threads as they don't implement the `Sync` trait.

This PR adds the `Sync` trait as an optional feature to the code generation. In some tests within the [bevy game engine](https://bevyengine.org/), it was a safe workaround to wrap the libfmod types in wrapper types that implement `Sync`.

Now, I'm not an expert in threading. I have talked to some people in the bevy Discord that use similar workarounds. AS the FMOD docs say, this *should* be safe™️. Hence, I implemented this as an optional feature, so people can test it at their own discretion, as it hard to test all edge cases right now.

Please let me know your thoughts 😄 

Follow-up: Add feature to `Cargo.toml` in the [libfmod repo](https://github.com/lebedec/libfmod).